### PR TITLE
Add expander port to distance tracker

### DIFF
--- a/include/legs/chassis/distance_tracker.hpp
+++ b/include/legs/chassis/distance_tracker.hpp
@@ -26,6 +26,7 @@ namespace legs {
     class LegsDistanceTracker: BaseDistanceTracker {
         public:
             LegsDistanceTracker(unsigned int port_num, legs::distance_tracker_type type, bool reverse, double tpi);
+            LegsDistanceTracker(unsigned int port_num, int expander_port, bool reverse, double tpi);
             double get_dist_traveled();
         private:
             int port_num;

--- a/src/legs/chassis/distance_tracker.cpp
+++ b/src/legs/chassis/distance_tracker.cpp
@@ -39,10 +39,11 @@ namespace legs {
         this->type = LEGS_ADI_ENCODER;
         this->tpi = tpi;
 
-        if(!validate_port_adi(port_num)) {
+        if(!validate_port_adi(port_num) || !validate_port_adi(expander_port)) {
             printf(LEGS_ERR_INVALID_ENCODER_PORT);
             return;
         }
+
         enc = std::make_shared<pros::ADIEncoder>(std::tuple<int, int, int>({expander_port, port_num, port_num + 1}), port_num < 0);
         enc->reset();
     }

--- a/src/legs/chassis/distance_tracker.cpp
+++ b/src/legs/chassis/distance_tracker.cpp
@@ -31,6 +31,22 @@ namespace legs {
         }
     }
 
+    LegsDistanceTracker::LegsDistanceTracker(unsigned int port_num, int expander_port, bool reverse, double tpi) {
+        
+        port_num = port_num >=97 ? port_num - 96 : port_num >=65 ? port_num -64 : port_num; // :)
+        
+        this->port_num = port_num;
+        this->type = LEGS_ADI_ENCODER;
+        this->tpi = tpi;
+
+        if(!validate_port_adi(port_num)) {
+            printf(LEGS_ERR_INVALID_ENCODER_PORT);
+            return;
+        }
+        enc = std::make_shared<pros::ADIEncoder>(std::tuple<int, int, int>({expander_port, port_num, port_num + 1}), port_num < 0);
+        enc->reset();
+    }
+
     double LegsDistanceTracker::get_dist_traveled() {
         if(this->type == LEGS_ROTATION) {
             return rot->get_position() * this->tpi;

--- a/src/legs/chassis/distance_tracker.cpp
+++ b/src/legs/chassis/distance_tracker.cpp
@@ -39,7 +39,7 @@ namespace legs {
         this->type = LEGS_ADI_ENCODER;
         this->tpi = tpi;
 
-        if(!validate_port_adi(port_num) || !validate_port_adi(expander_port)) {
+        if(!validate_port_adi(port_num) || !validate_port_smart(expander_port)) {
             printf(LEGS_ERR_INVALID_ENCODER_PORT);
             return;
         }


### PR DESCRIPTION
Added a second constructor for the case where we use an ADI encoder along with an expander port.