### PR TITLE
Fix oscillations when near target

### DIFF
--- a/src/VOSS/controller/PIDController.cpp
+++ b/src/VOSS/controller/PIDController.cpp
@@ -30,7 +30,7 @@ chassis::ChassisCommand PIDController::get_command(bool reverse, bool thru) {
 	angle_error = voss::norm_delta(angle_error);
 
 	if (distance_error <= exit_error) {
-		angle_error = 0;
+		total_lin_err = 0;
 		close += 10;
 	} else {
 		close = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,8 +93,8 @@ void opcontrol() {
 		if (master.get_digital_new_press(DIGITAL_Y)) {
 			odom.set_pose(voss::Pose{0.0, 0.0, 0.0});
 
-			//chassis.move(voss::Point{24.0, 0.0});
-			chassis.turn(90);
+			chassis.move(voss::Point{24.0, 0.0});
+			//chassis.turn(90);
 		}
 
 		pros::lcd::clear_line(1);


### PR DESCRIPTION
Previously set angle_error to 0 when close to target, which causes some issues. Also set total_lin_error to 0 when cloase to target so we don't have integral windup.