### PR TITLE
Improve Settling

### DIFF
--- a/src/VOSS/controller/PIDController.cpp
+++ b/src/VOSS/controller/PIDController.cpp
@@ -29,7 +29,7 @@ chassis::ChassisCommand PIDController::get_command(bool reverse, bool thru) {
 
 	angle_error = voss::norm_delta(angle_error);
 
-	if (distance_error <= exit_error) {
+	if (distance_error <= exit_error || (distance_error < min_error && fabs(cos(angle_error)) <= 0.1)) {
 		total_lin_err = 0;
 		close += 10;
 	} else {


### PR DESCRIPTION
When the distance error is less than min_error, we multiply lin_speed by the cosine of the angular error. This causes issues when the distance error is greater than the exit error but the cosine of the angular error is close to zero, since the robot is not moving but still won't exit out of the movement.

To fix this, I added another condition to our settling logic, where count will be incremented when distance error is less than exit error or when distance error is less than min error and the cosine of the angular error is less than 0.1.